### PR TITLE
[jinja_autoescape] Add jinja autoescape to resolve bandit fail

### DIFF
--- a/ydf/templating.py
+++ b/ydf/templating.py
@@ -39,7 +39,7 @@ def _environ(path=DEFAULT_TEMPLATE_PATH, **kwargs):
     kwargs.setdefault('lstrip_blocks', True)
     kwargs.setdefault('undefined', jinja2.StrictUndefined)
 
-    env = jinja2.Environment(loader=jinja2.FileSystemLoader(path), **kwargs)
+    env = jinja2.Environment(autoescape=True, loader=jinja2.FileSystemLoader(path), **kwargs)
     env.globals[instructions.convert_instruction.__name__] = instructions.convert_instruction
 
     return env


### PR DESCRIPTION
Add jinja `autoescape=True` to resolve seclint failure that
requires jinja autoescape to prevent XSS vulerabilities.

Jinja autoescape... autoescapes... HTML input in templates,
which isn't a concern in the creation of dockerfiles.

Resolves #196